### PR TITLE
Re-enable VS2019 compatability

### DIFF
--- a/MinimalisticView/Extensions.cs
+++ b/MinimalisticView/Extensions.cs
@@ -51,5 +51,25 @@ namespace MinimalisticView
 					action(obj1);
 			}
 		}
+
+		public static FrameworkElement FindElement(this Visual v, string name)
+		{
+			if (v == null)
+				return null;
+			for (var i = 0; i < VisualTreeHelper.GetChildrenCount(v); ++i)
+			{
+				var child = VisualTreeHelper.GetChild(v, i) as Visual;
+				if (child != null)
+				{
+					var e = child as FrameworkElement;
+					if (e != null && e.Name == name)
+						return e;
+				}
+				var result = FindElement(child, name);
+				if (result != null)
+					return result;
+			}
+			return null;
+		}
 	}
 }

--- a/MinimalisticView/MinimalisticView.cs
+++ b/MinimalisticView/MinimalisticView.cs
@@ -12,17 +12,19 @@ using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System.Windows.Threading;
+using System.Threading;
+using Task = System.Threading.Tasks.Task;
 
 namespace MinimalisticView
 {
-	[PackageRegistration(UseManagedResourcesOnly = true)]
+	[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
 	[InstalledProductRegistration("#110", "#112", "2.2", IconResourceID = 400)] // Info on this package for Help/About
 	[Guid(MinimalisticView.PackageGuidString)]
-	[ProvideAutoLoad(UIContextGuids.NoSolution)]
-	[ProvideAutoLoad(UIContextGuids.SolutionExists)]
+	[ProvideAutoLoad(UIContextGuids.NoSolution, PackageAutoLoadFlags.BackgroundLoad)]
+	[ProvideAutoLoad(UIContextGuids.SolutionExists, PackageAutoLoadFlags.BackgroundLoad)]
 	// todo: ensure that it correctly handles localized "Environment" category
 	[ProvideOptionPage(typeof(OptionPage), "Environment", "MinimalisticView", 0, 0, true, new[] { "MinimalisticView", "menu", "tab", "title", "hide" })]
-	public sealed partial class MinimalisticView : Package
+	public sealed partial class MinimalisticView : AsyncPackage
 	{
 		public const string PackageGuidString = "a06e17e0-8f3f-4625-ac80-b80e2b4a0699";
 
@@ -67,6 +69,18 @@ namespace MinimalisticView
 			}
 		}
 
+		private FrameworkElement _feedbackPanel;
+		public FrameworkElement FeedbackPanel
+		{
+			get {
+				return _feedbackPanel;
+			}
+			set {
+				_feedbackPanel = value;
+				UpdateFeedbackVisibility();
+			}
+		}
+
 		private OptionPage _options;
 		public OptionPage Options
 		{
@@ -106,6 +120,11 @@ namespace MinimalisticView
 			} else {
 				_titleBar.ClearValue(FrameworkElement.HeightProperty);
 			}
+		}
+
+		void UpdateFeedbackVisibility()
+		{
+			_feedbackPanel.Visibility = Options.HideFeedback ? Visibility.Collapsed : Visibility.Visible;
 		}
 
 		void UpdateElementHeight(FrameworkElement element, double collapsedHeight = 0)
@@ -202,9 +221,11 @@ namespace MinimalisticView
 		/// Initialization of the package; this method is called right after the package is sited, so this is the place
 		/// where you can put all the initialization code that rely on services provided by VisualStudio.
 		/// </summary>
-		protected override void Initialize()
+		protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
 		{
-			base.Initialize();
+			await base.InitializeAsync(cancellationToken, progress);
+			await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
 			_mainWindow = Application.Current.MainWindow;
 			if (_mainWindow == null) {
 				Trace.TraceError("mainWindow is null");
@@ -235,6 +256,9 @@ namespace MinimalisticView
 				case nameof(Options.HideMenuOnly):
 					UpdateMenuHeight();
 					UpdateTitleHeight();
+					break;
+				case nameof(Options.HideFeedback):
+					UpdateFeedbackVisibility();
 					break;
 				case nameof(Options.HideTabs):
 					var dics = Application.Current.Resources.MergedDictionaries;
@@ -273,6 +297,9 @@ namespace MinimalisticView
 				if (titleBar != null) {
 					TitleBar = titleBar;
 				}
+			}
+			if (FeedbackPanel == null) {
+				FeedbackPanel = Application.Current.MainWindow.FindElement("FrameControlContainerBorder");
 			}
 			if (TitleBar != null && MenuBar != null) {
 				_mainWindow.LayoutUpdated -= DetectLayoutElements;

--- a/MinimalisticView/MinimalisticView.cs
+++ b/MinimalisticView/MinimalisticView.cs
@@ -124,7 +124,9 @@ namespace MinimalisticView
 
 		void UpdateFeedbackVisibility()
 		{
-			_feedbackPanel.Visibility = Options.HideFeedback ? Visibility.Collapsed : Visibility.Visible;
+			if (_feedbackPanel != null) {
+				_feedbackPanel.Visibility = Options.HideFeedback ? Visibility.Collapsed : Visibility.Visible;
+			}
 		}
 
 		void UpdateElementHeight(FrameworkElement element, double collapsedHeight = 0)

--- a/MinimalisticView/MinimalisticView.csproj
+++ b/MinimalisticView/MinimalisticView.csproj
@@ -100,19 +100,24 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.15.0.15.0.26201\lib\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Framework.15.0.26201\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.UI.Internal, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Microsoft.VisualStudio.Shell.UI.Internal.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Microsoft.VisualStudio.Shell.UI.Internal.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.ViewManager">
       <HintPath>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Microsoft.VisualStudio.Shell.ViewManager.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.8.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="WindowsBase" />

--- a/MinimalisticView/NonClientMouseTracker.cs
+++ b/MinimalisticView/NonClientMouseTracker.cs
@@ -7,7 +7,7 @@ using System.Windows.Interop;
 
 namespace MinimalisticView
 {
-	public sealed partial class MinimalisticView : Package
+	public sealed partial class MinimalisticView : AsyncPackage
 	{
 		public class NonClientMouseTracker
 		{

--- a/MinimalisticView/OptionPage.cs
+++ b/MinimalisticView/OptionPage.cs
@@ -60,6 +60,24 @@ namespace MinimalisticView
 			}
 		}
 
+		bool _hideFeedback = true;
+		[DisplayName("Hide feedback button")]
+		[Description("Hide Feedback button panel")]
+		public bool HideFeedback
+		{
+			get {
+				return _hideFeedback;
+			}
+			set {
+				if (_hideFeedback == value) {
+					return;
+				}
+
+				_hideFeedback = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HideFeedback)));
+			}
+		}
+
 		int _collapsedTitleHeight = 2;
 		[DisplayName("Collapsed title height")]
 		[Description("Height of collapsed title bar. If set to zero removes it completely but menu cannot expand on mouse over.")]

--- a/MinimalisticView/packages.config
+++ b/MinimalisticView/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudio.Shell.14.0" version="14.3.25407" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="10.0.30319" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net45" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.26201" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.0.240" targetFramework="net45" />
 </packages>

--- a/MinimalisticView/source.extension.vsixmanifest
+++ b/MinimalisticView/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="MinimalisticView.Company.ba901288-7632-4116-b9e7-c9d29f495474" Version="3.3" Language="en-US" Publisher="Roman Semenov" />
+    <Identity Id="MinimalisticView.Company.ba901288-7632-4116-b9e7-c9d29f495474" Version="3.1" Language="en-US" Publisher="Roman Semenov" />
     <DisplayName>Hide Main Menu, Title Bar, and Tabs</DisplayName>
     <Description xml:space="preserve">Hides main menu and title bar when not in use, can also hide tabs. Menu and title behave as a single panel and are shown on mouse over or alt/ctrl-q shortcuts. Has configurable options.</Description>
     <MoreInfo>https://marketplace.visualstudio.com/items?itemName=Poma.MinimalisticView</MoreInfo>
@@ -10,7 +10,7 @@
     <Tags>TabStrip, menu, tabs, hide menu, collapse, hide, Main Menu, Title Bar, titlebar, hide tabs, hide title</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,16.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
@@ -20,6 +20,6 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Re-enable VS2019 compatability.
- Add back the VS2019 compatability commits that added async and updated config versions.
- Add null check on FeedbackPanel that was causing VS2017 crashes.